### PR TITLE
Add cowmachine_req functions to access controller and controller_options.

### DIFF
--- a/src/cowmachine_proxy.erl
+++ b/src/cowmachine_proxy.erl
@@ -55,7 +55,7 @@ update_req_direct(Req) ->
     {Peer, _Port} = cowboy_req:peer(Req),
     Req#{
         cowmachine_proxy => false,
-        cowmachine_forwarded_host => parse_host(cowboy_req:header(<<"host">>, Req)),
+        cowmachine_forwarded_host => parse_host(maps:get(host, Req)),
         cowmachine_forwarded_port => cowboy_req:port(Req),
         cowmachine_forwarded_proto => cowboy_req:scheme(Req),
         cowmachine_remote_ip => Peer,

--- a/src/cowmachine_req.erl
+++ b/src/cowmachine_req.erl
@@ -27,6 +27,9 @@
     ]).
 
 -export([
+    controller/1,
+    controller_options/1,
+
     site/1,
     method/1,
     version/1,
@@ -168,7 +171,10 @@ init_req(Req0, Env) ->
         cowmachine_disp_path => proplists:get_value('*', Bindings),
         cowmachine_range_ok => true,
 
-        cowmachine_cookies => cowboy_req:parse_cookies(Req)
+        cowmachine_cookies => cowboy_req:parse_cookies(Req),
+
+        cowmachine_controller => maps:get(controller, Env),
+        cowmachine_controller_options => maps:get(controller_options, Env, [])
     }.
 
 ensure_proxy_args(Req) ->
@@ -191,6 +197,15 @@ req(Context) when is_tuple(Context) ->
 req(Req) when is_map(Req) ->
     Req.
 
+%% @doc Return the current cowmachine controller
+-spec controller(context()) -> module().
+controller(Context) ->
+    maps:get(controller, req(Context)).
+
+%% @doc Return the current cowmachine controller options
+-spec controller_options(context()) -> list().
+controller_options(Context) ->
+    maps:get(controller_options, req(Context)).
 
 %% @doc Return the cowmachine site.
 -spec site(context()) -> atom().

--- a/test/cowmachine_proxy_tests.erl
+++ b/test/cowmachine_proxy_tests.erl
@@ -10,8 +10,8 @@ cowmachine_metadata_test() ->
         peer => {{127,0,0,1},1234},
         scheme => <<"http">>,
         port => 8000,
+        host => <<"local.dev">>,
         headers => #{
-            <<"host">> => <<"local.dev">>
         }
     },
     #{
@@ -90,8 +90,8 @@ cowmachine_x_forwarded_test() ->
         peer => {{127,0,0,1},1234},
         scheme => <<"http">>,
         port => 8000,
+        host => <<"local.dev">>,
         headers => #{
-            <<"host">> => <<"local.dev">>,
             <<"x-forwarded-for">> => <<"192.0.2.60">>,
             <<"x-forwarded-host">> => <<"example.com">>,
             <<"x-forwarded-proto">> => <<"https">>,
@@ -113,8 +113,8 @@ cowmachine_forwarded_untrusted_test() ->
         peer => {{1,2,3,4},1234},
         scheme => <<"http">>,
         port => 8000,
+        host => <<"local.dev">>,
         headers => #{
-            <<"host">> => <<"local.dev">>,
             <<"forwarded">> => <<"for=192.0.2.60; proto=https; by=203.0.113.43; host=\"example.com\"">>
         }
     },


### PR DESCRIPTION
So that there is a well defined way for controllers to fetch their dispatcher options.

Also fix an issue with http2 connections where the 'host' header is not passed.