### PR TITLE
Ensure that the websocket handler is loaded

### DIFF
--- a/src/cowmachine_websocket_upgrade.erl
+++ b/src/cowmachine_websocket_upgrade.erl
@@ -12,5 +12,11 @@ upgrade(Handler, Context) ->
     Opts = #{
         idle_timeout => infinity
     },
+
+    % Ensure the handler module is loaded. Cowboy uses erlang:function_exported/3 to
+    % check if optional callbacks are available. When the handler module is not loaded
+    % yet it will not call the optional callbacks for the first request. This ensures
+    % the module will be loaded.
     {module, Handler} = code:ensure_loaded(Handler),
+
     cowboy_websocket:upgrade(Req, Env, Handler, Context, Opts).

--- a/src/cowmachine_websocket_upgrade.erl
+++ b/src/cowmachine_websocket_upgrade.erl
@@ -12,4 +12,5 @@ upgrade(Handler, Context) ->
     Opts = #{
         idle_timeout => infinity
     },
+    {module, Handler} = code:ensure_loaded(Handler),
     cowboy_websocket:upgrade(Req, Env, Handler, Context, Opts).


### PR DESCRIPTION
Fixes: #11 

Ensure the websocket handler is loaded. Cowboy uses `erlang:function_exported/3` to look for callbacks. This does not automatically load the module. Adding this ensures the handler module is loaded before upgrading the websocket.

