### PR TITLE
Give a 400 error on illegal percent encoding.

### DIFF
--- a/src/cowmachine.erl
+++ b/src/cowmachine.erl
@@ -99,6 +99,9 @@ request_1(Controller, Req, Env, Options, Context) ->
             handle_stop_request(ResponseCode, Site, undefined, Req, Env, State, Context);
         throw:{stop_request, ResponseCode} when is_integer(ResponseCode) ->
             {stop, cowboy_req:reply(ResponseCode, Req)};
+        throw:invalid_percent_encoding ->
+            log(#{ at => ?AT, level => error, code => 400, text => "Illegal percent encoding" }, Req),
+            {stop, cowboy_req:reply(400, Req)};
         throw:Reason:Stacktrace ->
             log(#{ at => ?AT, level => error, code => 500, text => "Unexpected throw",
                    class => throw, reason => Reason,

--- a/src/cowmachine_util.erl
+++ b/src/cowmachine_util.erl
@@ -311,7 +311,9 @@ parse_qs_value(<< $&, Rest/bits >>, Acc, Name, Value) ->
 parse_qs_value(<< C, Rest/bits >>, Acc, Name, Value) when C =/= $% ->
     parse_qs_value(Rest, Acc, Name, << Value/bits, C >>);
 parse_qs_value(<<>>, Acc, Name, Value) ->
-    lists:reverse([{Name, Value}|Acc]).
+    lists:reverse([{Name, Value}|Acc]);
+parse_qs_value(_Rest, _Acc, _Name, _Value) ->
+    throw(invalid_percent_encoding).
 
 unhex($0) ->  0;
 unhex($1) ->  1;
@@ -334,7 +336,8 @@ unhex($b) -> 11;
 unhex($c) -> 12;
 unhex($d) -> 13;
 unhex($e) -> 14;
-unhex($f) -> 15.
+unhex($f) -> 15;
+unhex(_) -> throw(invalid_percent_encoding).
 
 
 %% author Bob Ippolito <bob@mochimedia.com>


### PR DESCRIPTION
This fixes an issue where crashed on illegal percent encoding of query arguments.

The crash in itself was ok. However:

- the resulting 500 should have been a 400 error;
- the crash logs were spamming the log files.