### PR TITLE
Remove catch on decision flow crashes, let cowmachine handle it.

### DIFF
--- a/src/cowmachine_decision_core.erl
+++ b/src/cowmachine_decision_core.erl
@@ -32,13 +32,8 @@
 -include("cowmachine_log.hrl").
 
 handle_request(#cmstate{ controller = Controller } = CmState, Context) ->
-    try
-        code:ensure_loaded(Controller),
-        d(v3b13, CmState, Context)
-    catch
-        error:Error:Stacktrace ->
-            throw({stop_request, 500, {Error, Stacktrace}})
-    end.
+    code:ensure_loaded(Controller),
+    d(v3b13, CmState, Context).
 
 %% @doc Call the controller
 -spec controller_call(atom(), #cmstate{}, term()) -> {term(), #cmstate{}, term()}.


### PR DESCRIPTION
Handling the crashes in the decision flow by the cowmachine middleware gives better stack traces and is simpler.