### PR TITLE
General improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,4 @@
 .eunit
-doc/
 deps
 *.o
 *.beam
@@ -14,3 +13,6 @@ _build
 _checkout
 compile_commands.json
 rebar3
+doc/*
+!doc/style.css
+!doc/overview.edoc

--- a/Makefile
+++ b/Makefile
@@ -22,6 +22,15 @@ xref: $(REBAR)
 clean:
 	$(REBAR) clean
 
+##
+## Doc targets
+##
+docs: $(REBAR)
+	$(REBAR) edoc
+
+edoc_private: $(REBAR)	
+	$(REBAR) as edoc_private edoc
+
 $(REBAR):
 	$(ERL) -noshell -s inets -s ssl \
 	  -eval '{ok, saved_to_file} = httpc:request(get, {"$(REBAR_URL)", []}, [], [{stream, "$(REBAR)"}])' \

--- a/doc/overview.edoc
+++ b/doc/overview.edoc
@@ -1,0 +1,5 @@
+@author Marc Worrell <marc@worrell.nl>
+@title cowmachine
+@doc Webmachine for <a href="http://zotonic.com/">Zotonic</a> and <a href="https://ninenines.eu/">Cowboy</a>.
+@copyright Apache-2.0
+@reference This is an adaptation of <a href="https://github.com/webmachine/webmachine">webmachine</a> for the Cowboy web server.

--- a/doc/style.css
+++ b/doc/style.css
@@ -1,0 +1,75 @@
+/* standard EDoc style sheet */
+body {
+	font-family: Verdana, Arial, Helvetica, sans-serif;
+      	margin-left: .25in;
+       	margin-right: .2in;
+       	margin-top: 0.2in;
+       	margin-bottom: 0.2in;
+       	color: #000000;
+       	background-color: #ffffff;
+}
+h1,h2 {
+ 	margin-left: -0.2in;
+}
+div.navbar {
+	background-color: #add8e6;
+	padding: 0.2em;
+}
+h2.indextitle {
+	padding: 0.4em;
+	background-color: #add8e6;
+}
+h3.function,h3.typedecl {
+	background-color: #add8e6;
+ 	padding-left: 1em;
+}
+div.spec {
+ 	margin-left: 2em;
+	
+	background-color: #eeeeee;
+}
+a.module {
+	text-decoration:none
+}
+a.module:hover {
+	background-color: #eeeeee;
+}
+ul.definitions {
+	list-style-type: none;
+}
+ul.index {
+	list-style-type: none;
+	background-color: #eeeeee;
+}
+
+/*
+ * Minor style tweaks
+ */
+ul {
+	list-style-type: square;
+}
+table {
+	border-collapse: collapse;
+}
+td {
+	padding: 3px;
+	vertical-align: middle;
+}
+
+/*
+Tune styles
+*/
+
+table[summary="navigation bar"] {
+	background-image: url('http://zotonic.com/lib/images/logo.png');
+	background-repeat: no-repeat;
+	background-position: center;
+}
+
+code, p>tt, a>tt {
+	font-size: 1.2em;
+}
+
+p {
+	line-height: 1.5;
+}

--- a/rebar.config
+++ b/rebar.config
@@ -18,12 +18,28 @@
         ]},
 
         {xref_ignores, [
-        ]},
-
-        {dialyzer, [
+        ]}
+    ]},
+	{edoc_private, [
+		{edoc_opts, [
+			{private, true}
+		]}
+	]},
+	{check, [
+	    {dialyzer, [
           {warnings, [
               no_return
           ]}
-        ]}
-    ]}
+        ]},
+		
+		{erl_opts, [
+			debug_info
+		]}
+	]
+	}
+]}.
+
+
+{edoc_opts, [
+    {preprocess, true}, {stylesheet, "style.css"}
 ]}.

--- a/src/cowmachine_accept_language.erl
+++ b/src/cowmachine_accept_language.erl
@@ -2,6 +2,7 @@
 %% @copyright 2017-2019 Marc Worrell
 %%
 %% @doc Accept-Language handling.
+%% @end
 
 %% Copyright 2017-2019 Marc Worrell
 %%
@@ -26,9 +27,10 @@
     accept_list/2
     ]).
 
-
--spec accept_header([{binary(),[ binary() ]}], cowmachine_req:context()|binary()|undefined) ->
-        {ok, binary()} | {error, nomatch|header}.
+-spec accept_header(AvailableLangs, AcceptHeader) -> Result when
+    AvailableLangs :: [{binary(),[ binary() ]}],
+	AcceptHeader :: cowmachine_req:context() | binary() | undefined,
+	Result :: {ok, binary()} | {error, nomatch | header}.
 accept_header(_AvailableLangs, undefined) ->
     {error, nomatch};
 accept_header(AvailableLangs, AcceptHeader) when is_binary(AcceptHeader) ->
@@ -46,6 +48,9 @@ accept_header(AvailableLangs, AcceptHeader) when is_binary(AcceptHeader) ->
 accept_header(AvailableLangs, Context) ->
     accept_header(AvailableLangs, cowmachine_req:get_req_header(<<"accept-language">>, Context)).
 
+-spec parse(AcceptHeader) -> Result when
+	AcceptHeader :: binary(),
+	Result :: [{binary(), cow_http_hd:qvalue()}] | error.
 parse(AcceptHeader) ->
     try
         cow_http_hd:parse_accept_language(AcceptHeader)
@@ -54,8 +59,10 @@ parse(AcceptHeader) ->
     end.
 
 
--spec accept_list([{binary(), [ binary() ]}], [binary()]) ->
-        {ok, binary()} | {error, nomatch}.
+-spec accept_list(AvailableLangs, AcceptableLangs) -> Result when	
+	AvailableLangs :: [{binary(), [ binary() ]}], 
+	AcceptableLangs :: [binary()],
+	Result :: {ok, binary()} | {error, nomatch}.
 accept_list(AvailableLangs, AcceptableLangs) ->
     case match_language(AvailableLangs, AcceptableLangs) of
         {ok, _} = OK -> OK;
@@ -68,10 +75,16 @@ accept_list(AvailableLangs, AcceptableLangs) ->
             end
     end.
 
+-spec sort_accept(List) -> Result when
+	List :: list(),
+	Result :: list().
 sort_accept([]) -> [];
 sort_accept(List) ->
     lists:keysort(2, fix_order(List,1,[])).
 
+-spec ensure_baselangs(Langs) -> Result when
+	Langs :: list(),
+	Result :: list().
 ensure_baselangs(Langs) ->
     lists:foldl(
         fun
@@ -90,11 +103,24 @@ ensure_baselangs(Langs) ->
 
 % Modify the priority so that for languages with equal priority the first mentioned
 % will be chosen.
+
+-spec fix_order(LangList, N, Acc) -> Result when
+	LangList :: [LangItem],
+	LangItem :: {Lang, Prio},
+	Lang :: binary(), 
+	Prio :: integer(),
+	N :: non_neg_integer(),
+	Acc :: LangList,
+	Result :: Acc.
 fix_order([], _N, Acc) ->
     Acc;
 fix_order([{Lang,Prio}|Langs], N, Acc) ->
     fix_order(Langs, N+1, [{Lang, Prio*100-N}|Acc]).
 
+-spec match_language(AvailableLangs, AcceptList) -> Result when
+	AvailableLangs :: [{binary(), [ binary() ]}], 
+	AcceptList :: [binary()],
+	Result :: {ok, binary()} | error.
 match_language(AvailableLangs, AcceptList) ->
     case firstmap(fun(Lang) -> available_language(Lang, AvailableLangs) end, AcceptList) of
         {ok, _} = OK -> OK;
@@ -116,6 +142,11 @@ available_language(Lang, AvailableLangs) ->
         false -> error
     end.
 
+-spec fallback_language(Lang, [{AvailableLang,FallbackLangs}]) -> Result when
+	Lang :: binary(), 
+	AvailableLang :: binary(),
+	FallbackLangs :: [binary()],
+	Result :: error | {ok, AvailableLang}.
 fallback_language(_Lang, []) ->
     error;
 fallback_language(Lang, [{AvailableLang,FallbackLangs}|AvailableLangs]) ->
@@ -124,6 +155,9 @@ fallback_language(Lang, [{AvailableLang,FallbackLangs}|AvailableLangs]) ->
         false -> fallback_language(Lang, AvailableLangs)
     end.
 
+-spec main_languages(Accept) -> Result when
+	Accept :: [binary()],
+	Result :: [binary()].
 main_languages(Accept) ->
     Accept1 = lists:foldl(
         fun

--- a/src/cowmachine_controller.erl
+++ b/src/cowmachine_controller.erl
@@ -1,6 +1,7 @@
 %% @author Justin Sheehy <justin@basho.com>
 %% @author Andy Gross <andy@basho.com>
 %% @copyright 2007-2009 Basho Technologies
+%% @end
 %%
 %%    Licensed under the Apache License, Version 2.0 (the "License");
 %%    you may not use this file except in compliance with the License.
@@ -26,6 +27,13 @@
 
 -include("cowmachine_state.hrl").
 
+-export_type([cmstate/0]).
+
+%% @doc Get default value by Key.
+-spec default(DefaultID, Context) -> Result when
+	DefaultID:: service_available |	resource_exists |	auth_required |	is_authorized |	forbidden |	upgrades_provided |	allow_missing_post |	malformed_request |	uri_too_long |	known_content_type |	valid_content_headers |	valid_entity_length |	options |	allowed_methods |	known_methods |	validate_content_checksum |	content_types_provided |	content_types_accepted |	delete_resource |	delete_completed |	post_is_create |	create_path |	base_uri |	process_post |	language_available |	charsets_provided |	content_encodings_provided |	transfer_encodings_provided |	variances |	is_conflict |	multiple_choices |	previously_existed |	moved_permanently |	moved_temporarily |	last_modified |	expires |	generate_etag |	finish_request,
+	Context :: cowmachine_req:context(),
+	Result :: no_charset | no_default | undefined | boolean() | list(binary()).
 default(service_available, _Context) ->
     true;
 default(resource_exists, _Context) ->
@@ -124,6 +132,10 @@ default(_, _Context) ->
 
 
 %% @doc Content types that are textual and should have a charset defined.
+
+-spec is_text(ContentType) -> Result when
+	ContentType :: cow_http_hd:media_type(),
+	Result :: boolean().
 is_text({<<"text">>, _, _}) -> true;
 is_text({<<"application">>, <<"x-javascript">>, _}) -> true;
 is_text({<<"application">>, <<"javascript">>, _}) -> true;
@@ -134,6 +146,14 @@ is_text(_Mime) -> false.
 
 %% @TODO Re-add logging code
 
+%% @doc Export and run function `Fun'.
+
+-spec do(Fun, State, Context) -> Result when
+	Fun :: atom(),
+	State :: cmstate(), 
+	Context :: cowmachine_req:context(),
+	Result :: {ContentType, Context},
+	ContentType :: cow_http_hd:media_type().
 do(Fun, #cmstate{ controller = Controller }, Context) when is_atom(Fun) ->
     case erlang:function_exported(Controller, Fun, 1) of
         true ->
@@ -145,6 +165,15 @@ do(Fun, #cmstate{ controller = Controller }, Context) when is_atom(Fun) ->
             end
     end.
 
+%% @doc Export and process `State' with `Context'.
+
+-spec do_process(ContentType, State, Context) -> Result when
+	ContentType :: cow_http_hd:media_type(), 
+	State :: cmstate(), 
+	Context :: cowmachine_req:context(),
+	Result :: {Res, Context},
+	Res :: boolean() | cowmachine_req:halt() | {error, any(), any()} | {error, any()} |
+			cowmachine_req:resp_body().
 do_process(ContentType, #cmstate{ controller = Controller }, Context) ->
     case erlang:function_exported(Controller, process, 4) of
         true ->

--- a/src/cowmachine_proxy.erl
+++ b/src/cowmachine_proxy.erl
@@ -1,7 +1,10 @@
 %% @author Marc Worrell <marc@worrell.nl>
 %% @copyright 2016-2019 Marc Worrell
 %%
-%% @doc Middleware to update proxy settings in the Cowboy Req
+%% @doc Middleware to update proxy settings in the Cowboy Req.
+%% @reference See more information related to Cowboy Req at 
+%% <a href="https://ninenines.eu/docs/en/cowboy/2.9/manual/cowboy_req/">cowboy_req(3)</a>.
+%% @end
 
 %% Copyright 2016-2019 Marc Worrell
 %%
@@ -31,13 +34,21 @@
 -include("cowmachine_log.hrl").
 
 %% @doc Cowboy middleware, route the new request. Continue with the cowmachine,
-%%      requests a redirect or return a 400 on an unknown host.
--spec execute(Req, Env) -> {ok, Req, Env} | {stop, Req}
-    when Req::cowboy_req:req(), Env::cowboy_middleware:env().
+%%      requests a redirect or return a `400' on an unknown host.
+
+-spec execute(Req, Env) -> Result when
+	Req :: cowboy_req:req(), 
+	Env :: cowboy_middleware:env(),
+	Result :: {ok, Req, Env} | {stop, Req}.
 execute(Req, Env) ->
     {ok, Req, update_env(Req, Env)}.
 
--spec update_env(cowboy_req:req(), cowboy_middleware:env()) -> cowboy_middleware:env().
+%% @doc Update the environment based on the content of the request.
+
+-spec update_env(Req, Env) -> Result when
+	Req :: cowboy_req:req(), 
+	Env :: cowboy_middleware:env(),
+	Result :: cowboy_middleware:env().
 update_env(Req, Env) ->
     case cowboy_req:header(<<"forwarded">>, Req) of
         undefined ->
@@ -51,7 +62,12 @@ update_env(Req, Env) ->
             update_env_proxy(Forwarded, Req, Env)
     end.
 
-%% @doc Fetch the metadata from the request itself
+%% @doc Fetch the metadata from the request itself.
+
+-spec update_env_direct(Req, Env) -> Result when
+	Req :: cowboy_req:req(), 
+	Env :: cowboy_middleware:env(),
+	Result :: cowboy_middleware:env().	
 update_env_direct(Req, Env) ->
     {Peer, _Port} = cowboy_req:peer(Req),
     Env#{
@@ -63,7 +79,13 @@ update_env_direct(Req, Env) ->
         cowmachine_remote => list_to_binary(inet_parse:ntoa(Peer))
     }.
 
-%% @doc Handle the "Forwarded" header, added by the proxy.
+%% @doc Handle the `Forwarded' header, added by the proxy.
+
+-spec update_env_proxy(Forwarded, Req, Env) -> Result when
+	Forwarded :: binary(), 
+	Req :: cowboy_req:req(), 
+	Env :: cowboy_middleware:env(),
+	Result :: cowboy_middleware:env().	
 update_env_proxy(Forwarded, Req, Env) ->
     {Peer, _Port} = cowboy_req:peer(Req),
     case is_trusted_proxy(Peer) of
@@ -104,7 +126,8 @@ update_env_proxy(Forwarded, Req, Env) ->
             update_env_direct(Req, Env)
     end.
 
-%% @doc Handle the "X-Forwarded-For" header, added by the proxy.
+%% @doc Handle the `X-Forwarded-For' header, added by the proxy.
+
 update_env_old_proxy(XForwardedFor, Req, Env) ->
     {Peer, _Port} = cowboy_req:peer(Req),
     case is_trusted_proxy(Peer) of
@@ -145,15 +168,27 @@ update_env_old_proxy(XForwardedFor, Req, Env) ->
 
     end.
 
+-spec trim(String) -> Result when
+	String :: undefined | iodata(),
+	Result :: undefined | binary().
 trim(undefined) -> undefined;
 trim(S) -> z_string:trim(S).
 
+-spec parse_host(Host) -> Result when
+	Host :: undefined | binary(),
+	Result :: undefined | binary().
 parse_host(undefined) ->
     undefined;
 parse_host(Host) ->
     {Host1, _} = cow_http_hd:parse_host(Host),
     sanitize_host(Host1).
 
+-spec parse_for(For, Req) -> Result when
+	For :: undefined | binary(),
+	Req :: cowboy_req:req(),
+	Result :: {Host, Adr},
+	Host :: binary(),
+	Adr :: inet:ip_address().
 parse_for(undefined, Req) ->
     {Peer, _Port} = cowboy_req:peer(Req),
     {list_to_binary(inet_parse:ntoa(Peer)), Peer};
@@ -171,44 +206,95 @@ parse_for(For, Req) ->
             {Peer, sanitize(For)}
     end.
 
+%% @equiv sanitize(For, <<>>)
+
+-spec sanitize(For) -> Result when
+	For :: binary(),
+	Result :: binary().
 sanitize(For) ->
     sanitize(For, <<>>).
 
+-spec sanitize(For, Acc) -> Result when
+	For :: binary(),
+	Acc :: binary(),
+	Result :: binary().
 sanitize(<<>>, Acc) -> Acc;
 sanitize(<<C, Rest/binary>>, Acc) when ?IS_URI_UNRESERVED(C) -> sanitize(Rest, <<Acc/binary, C>>);
 sanitize(<<_, Rest/binary>>, Acc) -> sanitize(Rest, <<Acc/binary, $->>).
 
--spec parse_forwarded(binary()) -> [{binary(), binary()}].
+%% @equiv forwarded_list(Header, [])
+
+-spec parse_forwarded(Header) -> Result when
+	Header :: binary(),
+	Result :: [{binary(), binary()}].
 parse_forwarded(Header) when is_binary(Header) ->
     forwarded_list(Header, []).
 
+-spec forwarded_list(Header, Acc) -> Result when
+	Header :: binary(),
+	Acc :: [{binary(),binary()}],
+	Result :: [{binary(),binary()}].
 forwarded_list(<<>>, Acc) -> lists:reverse(Acc);
 forwarded_list(<<$,, R/bits>>, _Acc) -> forwarded_list(R, []);
 forwarded_list(<< C, R/bits >>, Acc) when ?IS_WS(C) -> forwarded_list(R, Acc);
 forwarded_list(<< $;, R/bits >>, Acc) -> forwarded_list(R, Acc);
 forwarded_list(<< C, R/bits >>, Acc) when ?IS_ALPHANUM(C) -> forwarded_pair(R, Acc, << (lower(C)) >>).
 
+-spec forwarded_pair(Header, Acc, T) -> Result when
+	Header :: binary(), 
+	Acc :: [{binary(),binary()}], 
+	T :: binary(),
+	Result :: [{binary(),binary()}].
 forwarded_pair(<< C, R/bits >>, Acc, T) when ?IS_ALPHANUM(C) -> forwarded_pair(R, Acc, << T/binary, (lower(C)) >>);
 forwarded_pair(R, Acc, T) -> forwarded_pair_eq(R, Acc, T).
 
+-spec forwarded_pair_eq(Header, Acc, T) -> Result when
+	Header :: binary(), 
+	Acc :: [{binary(),binary()}], 
+	T :: binary(),
+	Result :: [{binary(),binary()}].
 forwarded_pair_eq(<< C, R/bits >>, Acc, T) when ?IS_WS(C) -> forwarded_pair_eq(R, Acc, T);
 forwarded_pair_eq(<< $=, R/bits >>, Acc, T) -> forwarded_pair_value(R, Acc, T).
 
+-spec forwarded_pair_value(Header, Acc, T) -> Result when
+	Header :: binary(), 
+	Acc :: [{binary(),binary()}], 
+	T :: binary(),
+	Result :: [{binary(),binary()}].
 forwarded_pair_value(<< C, R/bits>>, Acc, T) when ?IS_WS(C) -> forwarded_pair_value(R, Acc, T);
 forwarded_pair_value(<< $", R/bits>>, Acc, T) -> forwarded_pair_value_quoted(R, Acc, T, <<>>);
 forwarded_pair_value(<< C, R/bits>>, Acc, T) -> forwarded_pair_value_token(R, Acc, T, << (lower(C)) >>).
 
+-spec forwarded_pair_value_token(Header, Acc, T, V) -> Result when
+	Header :: binary(), 
+	Acc :: [{binary(),binary()}], 
+	T :: binary(),
+	V :: binary(),
+	Result :: [{binary(),binary()}].
 forwarded_pair_value_token(<< C, R/bits>>, Acc, T, V) when ?IS_TOKEN(C) -> forwarded_pair_value_token(R, Acc, T, << V/binary, (lower(C)) >>);
 forwarded_pair_value_token(R, Acc, T, V) -> forwarded_list(R, [{T, V}|Acc]).
 
+-spec forwarded_pair_value_quoted(Header, Acc, T, V) -> Result when
+	Header :: binary(), 
+	Acc :: [{binary(),binary()}], 
+	T :: binary(),
+	V :: binary(),
+	Result :: [{binary(),binary()}].
 forwarded_pair_value_quoted(<< $", R/bits >>, Acc, T, V) -> forwarded_list(R, [{T, V}|Acc]);
 forwarded_pair_value_quoted(<< $\\, C, R/bits >>, Acc, T, V) -> forwarded_pair_value_quoted(R, Acc, T, << V/binary, (lower(C)) >>);
 forwarded_pair_value_quoted(<< C, R/bits >>, Acc, T, V) -> forwarded_pair_value_quoted(R, Acc, T, << V/binary, (lower(C)) >>).
 
+-spec lower(Character) -> Result when
+	Character :: char(),
+	Result :: char().
 lower(C) when C >= $A, C =< $Z -> C + 32;
 lower(C) -> C.
 
 %% @doc Check if the given proxy is trusted.
+
+-spec is_trusted_proxy(Peer) -> Result when
+	Peer :: inet:ip_address(),
+	Result :: boolean().
 is_trusted_proxy(Peer) ->
     case application:get_env(cowmachine, proxy_allowlist) of
         {ok, ProxyAllowlist} ->
@@ -217,6 +303,12 @@ is_trusted_proxy(Peer) ->
             is_trusted_proxy(local, Peer)
     end.
 
+-spec is_trusted_proxy(Marker, Peer) -> Result when
+	Marker :: ProxyMarker | ProxyAllowlist,
+	ProxyMarker :: any | ip_whitelist | local | none,
+	ProxyAllowlist :: list() | binary(),
+	Peer :: inet:ip_address(),
+	Result :: boolean().
 is_trusted_proxy(none, _Peer) ->
     false;
 is_trusted_proxy(any, _Peer) ->
@@ -236,12 +328,20 @@ is_trusted_proxy(Allowlist, Peer) when is_list(Allowlist); is_binary(Allowlist) 
 
 % Extra host sanitization as cowboy is too lenient.
 % Cowboy did already do the lowercasing of the hostname
+
+-spec sanitize_host(Host) -> Result when
+	Host :: binary(),
+	Result :: binary().
 sanitize_host(<<$[, _/binary>> = Host) ->
     % IPv6 address, sanitized by cowboy
     Host;
 sanitize_host(Host) ->
     sanitize_host(Host, <<>>).
 
+-spec sanitize_host(Host, Acc) -> Result when
+	Host :: binary(),
+	Acc ::  binary(),
+	Result :: binary().
 sanitize_host(<<>>, Acc) -> Acc;
 sanitize_host(<<C, Rest/binary>>, Acc) when C >= $a, C =< $z -> sanitize_host(Rest, <<Acc/binary, C>>);
 sanitize_host(<<C, Rest/binary>>, Acc) when C >= $0, C =< $9 -> sanitize_host(Rest, <<Acc/binary, C>>);

--- a/src/cowmachine_state.hrl
+++ b/src/cowmachine_state.hrl
@@ -1,5 +1,3 @@
-%% @doc Data for cowmachine's decision core
-
 -record(cmstate, {
     % Cowboy state
     controller :: atom(),
@@ -9,5 +7,17 @@
     cache = #{} :: map(),
     options = #{} :: map()
 }).
+
+-type cmstate() :: #cmstate{
+	% Cowboy state
+    controller :: atom(),
+    is_process_called :: boolean(),
+
+    % Memo cache for controller calls
+    cache :: map(),
+    options :: map()
+}. %% Data for cowmachine's decision core
+
+
 
 -define(DBG(Msg), error_logger:info_msg("DEBUG: ~p:~p  ~p~n", [?MODULE, ?LINE, Msg])).

--- a/src/cowmachine_websocket_upgrade.erl
+++ b/src/cowmachine_websocket_upgrade.erl
@@ -5,7 +5,11 @@
     ]).
 
 %% @doc Upgrade the request to a websocket request
--spec upgrade(atom(), cowmachine_req:context()) -> {ok, cowboy_req:req(), cowboy_middleware:env()}.
+
+-spec upgrade(Handler, Context) -> Result when
+	Handler :: atom(), 
+	Context :: cowmachine_req:context(),
+	Result :: {ok, cowboy_req:req(), cowboy_middleware:env()}.
 upgrade(Handler, Context) ->
     Req = cowmachine_req:req(Context),
     Env = cowmachine_req:env(Context),


### PR DESCRIPTION
- Tune module descrition (exclude licence topic info from generating documentation by `@end` EDoc tag.
- Add documentation targets for generation `public` and `private` documenation.
- `-spec`. Simplified documentation content. Explicitly specified the name of function parameters in a uniform style.
Introduced a wider use of the features of EDoc.

- Provide a description of the data types (`-type`) that were in the source codes in the generated EDoc documentation. This in the code seems non-obvious and even strange. But please look at the output when generating the documentation. The result - we have documentation for types.

- `cowmachine_req.` Fix version documentation type. Arranged the version values in the correct order.

- rebar.config
  - Add documentation generation and testing profiles.
  - Add option to generate public and private documentation.
  - Moved the work with the dilyzer to a separate profile "check" from the "test" profile. It is more comfortable. It also speeds up work by doing only useful work.
- EDoc
  - Tune css stylesheet.