### PR TITLE
Remove the CSP response header on 304 response

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,7 +18,7 @@ jobs:
 
     strategy:
       matrix:
-        otp_version: [24,25,26]
+        otp_version: [25,26,27]
         os: [ubuntu-latest]
 
     container:

--- a/src/cowmachine_controller.erl
+++ b/src/cowmachine_controller.erl
@@ -31,9 +31,17 @@
 
 %% @doc Get default value by Key.
 -spec default(DefaultID, Context) -> Result when
-	DefaultID:: service_available |	resource_exists |	auth_required |	is_authorized |	forbidden |	upgrades_provided |	allow_missing_post |	malformed_request |	uri_too_long |	known_content_type |	valid_content_headers |	valid_entity_length |	options |	allowed_methods |	known_methods |	validate_content_checksum |	content_types_provided |	content_types_accepted |	delete_resource |	delete_completed |	post_is_create |	create_path |	base_uri |	process_post |	language_available |	charsets_provided |	content_encodings_provided |	transfer_encodings_provided |	variances |	is_conflict |	multiple_choices |	previously_existed |	moved_permanently |	moved_temporarily |	last_modified |	expires |	generate_etag |	finish_request,
-	Context :: cowmachine_req:context(),
-	Result :: no_charset | no_default | undefined | boolean() | list(binary()).
+    DefaultID:: service_available | resource_exists | auth_required | is_authorized |
+                forbidden | upgrades_provided | allow_missing_post | malformed_request |
+                uri_too_long | known_content_type | valid_content_headers | valid_entity_length |
+                options | allowed_methods | known_methods | validate_content_checksum |
+                content_types_provided | content_types_accepted | delete_resource | delete_completed |
+                post_is_create | create_path | base_uri | process_post | language_available |
+                charsets_provided | content_encodings_provided | transfer_encodings_provided |
+                variances | is_conflict | multiple_choices | previously_existed | moved_permanently |
+                moved_temporarily | last_modified | expires | generate_etag | finish_request,
+    Context :: cowmachine_req:context(),
+    Result :: no_charset | no_default | undefined | boolean() | list(binary()).
 default(service_available, _Context) ->
     true;
 default(resource_exists, _Context) ->
@@ -134,8 +142,8 @@ default(_, _Context) ->
 %% @doc Content types that are textual and should have a charset defined.
 
 -spec is_text(ContentType) -> Result when
-	ContentType :: cow_http_hd:media_type(),
-	Result :: boolean().
+    ContentType :: cow_http_hd:media_type(),
+    Result :: boolean().
 is_text({<<"text">>, _, _}) -> true;
 is_text({<<"application">>, <<"json">>, _}) -> true;
 is_text({<<"application">>, <<"ld+json">>, _}) -> true;
@@ -157,11 +165,11 @@ is_text(_) ->
 %% @doc Export and run function `Fun'.
 
 -spec do(Fun, State, Context) -> Result when
-	Fun :: atom(),
-	State :: cmstate(),
-	Context :: cowmachine_req:context(),
-	Result :: {ContentType, Context},
-	ContentType :: cow_http_hd:media_type().
+    Fun :: atom(),
+    State :: cmstate(),
+    Context :: cowmachine_req:context(),
+    Result :: {ContentType, Context},
+    ContentType :: cow_http_hd:media_type().
 do(Fun, #cmstate{ controller = Controller }, Context) when is_atom(Fun) ->
     case erlang:function_exported(Controller, Fun, 1) of
         true ->
@@ -176,12 +184,12 @@ do(Fun, #cmstate{ controller = Controller }, Context) when is_atom(Fun) ->
 %% @doc Export and process `State' with `Context'.
 
 -spec do_process(ContentType, State, Context) -> Result when
-	ContentType :: cow_http_hd:media_type(),
-	State :: cmstate(),
-	Context :: cowmachine_req:context(),
-	Result :: {Res, Context},
-	Res :: boolean() | cowmachine_req:halt() | {error, any(), any()} | {error, any()} |
-			cowmachine_req:resp_body().
+    ContentType :: cow_http_hd:media_type(),
+    State :: cmstate(),
+    Context :: cowmachine_req:context(),
+    Result :: {Res, Context},
+    Res :: boolean() | cowmachine_req:halt() | {error, any(), any()} | {error, any()} |
+            cowmachine_req:resp_body().
 do_process(ContentType, #cmstate{ controller = Controller }, Context) ->
     case erlang:function_exported(Controller, process, 4) of
         true ->


### PR DESCRIPTION
This fixes a problem where a controller can set a Content-Security-Policy header for a request that turns out to be a 304.

If a 304 with CSP is returned then the User-Agent will use the _new_ CSP for the _cached_ content.
This gives a problem if in the CSP a nonce is defined, as that nonce is different for every request.

Solution is to remove the CSP header for all 304 responses.