### PR TITLE
Fix edoc and add edoc CI test

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,5 +32,7 @@ jobs:
         run: make test
       - name: XRef
         run: make xref
+      - name: Edoc
+        run: make edoc
       - name: Dialyzer
         run: make dialyzer

--- a/src/cowmachine_util.erl
+++ b/src/cowmachine_util.erl
@@ -376,7 +376,7 @@ parse_qs(String) ->
     parse_qs(String, ?DEFAULT_MAX_QS).
 
 %% @doc Parse an `application/x-www-form-urlencoded' string. With a
-%% maximum number of parsed name/value pairs. If more that the given
+%% maximum number of parsed name/value pairs. If more than the given
 %% amount is parsed then `too_many_qs_names' is thrown. If a value is
 %% missing then the value is assumed to be the empty string.
 %% See also <a href="https://www.w3.org/TR/html401/interact/forms.html#didx-applicationx-www-form-urlencoded">specification</a>.

--- a/src/cowmachine_util.erl
+++ b/src/cowmachine_util.erl
@@ -367,7 +367,7 @@ do_choose(Default, DefaultOkay, AnyOkay, Choices, [{Acc,_Prio}|AccRest]) ->
 %% @doc Parse an `application/x-www-form-urlencoded' string. Returns a list
 %% of name/value pairs. If a value is missing then the value is assumed to
 %% be the empty string. Default the maximum number of name/value pairs returned
-%% is 10_000. More will throw `too_many_qs_names`.
+%% is 10_000. More will throw `too_many_qs_names'.
 %% See also <a href="https://www.w3.org/TR/html401/interact/forms.html#didx-applicationx-www-form-urlencoded">specification</a>.
 -spec parse_qs(String) -> Result when
     String :: binary(),
@@ -377,7 +377,7 @@ parse_qs(String) ->
 
 %% @doc Parse an `application/x-www-form-urlencoded' string. With a
 %% maximum number of parsed name/value pairs. If more that the given
-%% amount is parsed then `too_many_qs_names` is thrown. If a value is
+%% amount is parsed then `too_many_qs_names' is thrown. If a value is
 %% missing then the value is assumed to be the empty string.
 %% See also <a href="https://www.w3.org/TR/html401/interact/forms.html#didx-applicationx-www-form-urlencoded">specification</a>.
 -spec parse_qs(String, MaxNames) -> Result when


### PR DESCRIPTION
This pull request introduces a minor improvement to the CI workflow and makes small documentation corrections in the codebase. The most notable change is the addition of an Edoc (Erlang documentation) generation step to the GitHub Actions workflow, ensuring that documentation is built and checked as part of the CI process.

Continuous Integration improvements:
* Added an `Edoc` step to the `.github/workflows/test.yml` workflow to generate and check Erlang documentation during CI runs.

Documentation corrections:
* Fixed minor inconsistencies in the documentation comments in `src/cowmachine_util.erl` by standardizing the use of single quotes for the `too_many_qs_names` atom. [[1]](diffhunk://#diff-b1fa402620f3b5e2e0dd6c5c1f7d5ce9135bd1ac7164ff0974ea68767429d9c5L370-R370) [[2]](diffhunk://#diff-b1fa402620f3b5e2e0dd6c5c1f7d5ce9135bd1ac7164ff0974ea68767429d9c5L380-R380)