### PR TITLE
Fix ws limits

### DIFF
--- a/src/cowmachine_config.erl
+++ b/src/cowmachine_config.erl
@@ -1,0 +1,27 @@
+%% @author Maas-Maarten Zeeman <mmzeeman@xs4all.nl>
+%% @copyright 2026 Maas-Maarten Zeeman 
+%%
+%% @doc Retrieve cowmachine configuration options.
+%% @end
+
+-module(cowmachine_config).
+
+-export([
+    ws_opts/0,
+    env/2
+]).
+
+env(Key, Default) ->
+    case application:get_env(cowmachine, Key) of
+        {ok, V} -> V;
+        _ -> Default
+    end.
+
+% Reasonably safe websocket config.
+ws_opts() ->
+    #{
+      idle_timeout => env(ws_idle_timeout, 120000), % For slow clients while also preventing slow client DoS
+      max_frame_size => env(ws_max_frame_size, 524288), % 512kb
+      compress => env(ws_compress, true)
+     }.
+

--- a/src/cowmachine_config.erl
+++ b/src/cowmachine_config.erl
@@ -7,7 +7,6 @@
 -module(cowmachine_config).
 
 -export([
-    ws_opts/0,
     env/2
 ]).
 
@@ -16,12 +15,4 @@ env(Key, Default) ->
         {ok, V} -> V;
         _ -> Default
     end.
-
-% Reasonably safe websocket config.
-ws_opts() ->
-    #{
-      idle_timeout => env(ws_idle_timeout, 120000), % For slow clients while also preventing slow client DoS
-      max_frame_size => env(ws_max_frame_size, 524288), % 512kb
-      compress => env(ws_compress, true)
-     }.
 

--- a/src/cowmachine_proxy.erl
+++ b/src/cowmachine_proxy.erl
@@ -296,14 +296,14 @@ lower(C) -> C.
 	Peer :: inet:ip_address(),
 	Result :: boolean().
 is_trusted_proxy(Peer) ->
-    case application:get_env(cowmachine, proxy_allowlist) of
-        {ok, ip_whitelist} ->
+    case cowmachine_config:env(proxy_allowlist, undefined) of
+        undefined ->
+            is_trusted_proxy(local, Peer);
+        ip_whitelist ->
             % Map old config name
             is_trusted_proxy(ip_allowlist, Peer);
-        {ok, ProxyAllowlist} ->
-            is_trusted_proxy(ProxyAllowlist, Peer);
-        undefined ->
-            is_trusted_proxy(local, Peer)
+        ProxyAllowlist ->
+            is_trusted_proxy(ProxyAllowlist, Peer)
     end.
 
 -spec is_trusted_proxy(Marker, Peer) -> Result when
@@ -319,7 +319,7 @@ is_trusted_proxy(any, _Peer) ->
 is_trusted_proxy(local, Peer) ->
     z_ip_address:is_local(Peer);
 is_trusted_proxy(ip_allowlist, Peer) ->
-    case application:get_env(cowmachine, ip_allowlist) of
+    case cowmachine_config:env(ip_allowlist, undefined) of
         {ok, Allowlist} ->
             z_ip_address:ip_match(Peer, Allowlist);
         undefined ->

--- a/src/cowmachine_response.erl
+++ b/src/cowmachine_response.erl
@@ -37,18 +37,25 @@
 
 -define(FILE_CHUNK_LENGTH, 16#80000). % 512KB
 -define(DEFAULT_IDLE_TIMEOUT, 60000).
+-define(SERVER_NAME, <<"CowMachine">>).
 
 %% @doc Returns server header.
 -spec server_header() -> Result when
 	Result :: binary().
 server_header() ->
-    case application:get_env(cowmachine, server_header) of
-        {ok, Server} -> z_convert:to_binary(Server);
+    case cowmachine_config:env(server_header, undefined) of
         undefined ->
-            case application:get_key(cowmachine, vsn) of
-                {ok, Version} -> <<"CowMachine/", (z_convert:to_binary(Version))/binary>>;
-                undefined -> <<"CowMachine">>
-            end
+            default_server_header();
+        Server ->
+            z_convert:to_binary(Server)
+    end.
+
+default_server_header() ->
+    case cowmachine_config:env(vsn, undefined) of
+        undefined ->
+            ?SERVER_NAME;
+        Version ->
+            <<(?SERVER_NAME)/binary, "/", (z_convert:to_binary(Version))/binary>>
     end.
 
 %% @doc Send responce.

--- a/src/cowmachine_websocket_upgrade.erl
+++ b/src/cowmachine_websocket_upgrade.erl
@@ -14,8 +14,9 @@ upgrade(Handler, Context) ->
     Req = cowmachine_req:req(Context),
     Env = cowmachine_req:env(Context),
     Opts = #{
-        idle_timeout => infinity,
-        compress => true
+        idle_timeout   => 120000, % 2m still accept slow clients, but also prevent slow client DoS
+        max_frame_size => 524288, % 512 KB 
+        compress       => true
     },
 
     % Ensure the handler module is loaded. Cowboy uses erlang:function_exported/3 to

--- a/src/cowmachine_websocket_upgrade.erl
+++ b/src/cowmachine_websocket_upgrade.erl
@@ -13,11 +13,7 @@
 upgrade(Handler, Context) ->
     Req = cowmachine_req:req(Context),
     Env = cowmachine_req:env(Context),
-    Opts = #{
-        idle_timeout   => 120000, % 2m still accept slow clients, but also prevent slow client DoS
-        max_frame_size => 524288, % 512 KB 
-        compress       => true
-    },
+    Opts = cowmachine_config:ws_opts(),
 
     % Ensure the handler module is loaded. Cowboy uses erlang:function_exported/3 to
     % check if optional callbacks are available. When the handler module is not loaded

--- a/src/cowmachine_websocket_upgrade.erl
+++ b/src/cowmachine_websocket_upgrade.erl
@@ -13,7 +13,7 @@
 upgrade(Handler, Context) ->
     Req = cowmachine_req:req(Context),
     Env = cowmachine_req:env(Context),
-    Opts = cowmachine_config:ws_opts(),
+    Opts = ws_opts(Context),
 
     % Ensure the handler module is loaded. Cowboy uses erlang:function_exported/3 to
     % check if optional callbacks are available. When the handler module is not loaded
@@ -22,3 +22,20 @@ upgrade(Handler, Context) ->
     {module, Handler} = code:ensure_loaded(Handler),
 
     cowboy_websocket:upgrade(Req, Env, Handler, Context, Opts).
+
+% Reasonably safe websocket config.
+ws_opts(Context) ->
+    case cowmachine_req:get_metadata(ws_opts, Context) of
+        M when is_map(M) ->
+            maps:merge(ws_defaults, M);
+        _ ->
+            ws_defaults()
+    end.
+
+ws_defaults() ->
+    #{
+      idle_timeout => 120000, % For slow clients while also preventing slow client DoS
+      max_frame_size => 524288, % 512kb
+      compress => true
+     }.
+

--- a/src/cowmachine_websocket_upgrade.erl
+++ b/src/cowmachine_websocket_upgrade.erl
@@ -27,7 +27,7 @@ upgrade(Handler, Context) ->
 ws_opts(Context) ->
     case cowmachine_req:get_metadata(ws_opts, Context) of
         M when is_map(M) ->
-            maps:merge(ws_defaults, M);
+            maps:merge(ws_defaults(), M);
         _ ->
             ws_defaults()
     end.


### PR DESCRIPTION
Cowmachine uses the default `max_frame_size` setting from cowboy. This PR sets a safe limit, and allows for configuring the websocket options dynamically from a controller.